### PR TITLE
fix: replace missing placeholder images with picsum.photos URLs

### DIFF
--- a/packages/docs/src/content/docs/en/components/badge.mdx
+++ b/packages/docs/src/content/docs/en/components/badge.mdx
@@ -148,7 +148,7 @@ Badges with a close button (requires JavaScript):
 ### User Roles
 
 <ComponentShowcase title="User Role Badge" code={`<div class="flex items-center gap-2">
-  <img class="w-10 h-10 rounded-full" src="/avatar.jpg" alt="User" />
+  <img class="w-10 h-10 rounded-full" src="https://picsum.photos/seed/user1/80/80" alt="User" />
   <div>
     <div class="flex items-center gap-2">
       <span class="font-semibold">Jane Doe</span>

--- a/packages/docs/src/content/docs/en/components/chip.mdx
+++ b/packages/docs/src/content/docs/en/components/chip.mdx
@@ -174,12 +174,12 @@ Add leading icons to provide visual context:
 Use avatars for chips representing people or user-generated content:
 
 <ComponentShowcase title="Chips with Avatar" code={`<span class="chip">
-  <img src="/avatar1.jpg" alt="User avatar" class="chip-avatar" />
+  <img src="https://picsum.photos/seed/avatar1/64/64" alt="User avatar" class="chip-avatar" />
   John Doe
 </span>
 
 <span class="chip chip-primary">
-  <img src="/avatar2.jpg" alt="User avatar" class="chip-avatar" />
+  <img src="https://picsum.photos/seed/avatar2/64/64" alt="User avatar" class="chip-avatar" />
   Jane Smith
   <button class="chip-remove" aria-label="Remove Jane Smith">
     <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -206,7 +206,7 @@ Sizes work with all variants:
 </span>
 
 <span class="chip chip-lg chip-secondary">
-  <img src="/avatar.jpg" alt="Avatar" class="chip-avatar" />
+  <img src="https://picsum.photos/seed/avatar3/64/64" alt="Avatar" class="chip-avatar" />
   Large with Avatar
   <button class="chip-remove" aria-label="Remove">
     <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -551,7 +551,7 @@ Common chip combinations:
 
 <!-- Input chip: with avatar and remove button -->
 <span class="chip chip-primary">
-  <img src="/avatar.jpg" alt="User" class="chip-avatar" />
+  <img src="https://picsum.photos/seed/johndoe/64/64" alt="User" class="chip-avatar" />
   John Doe
   <button class="chip-remove" aria-label="Remove John Doe">×</button>
 </span>

--- a/packages/docs/src/content/docs/en/components/file-upload.mdx
+++ b/packages/docs/src/content/docs/en/components/file-upload.mdx
@@ -95,7 +95,7 @@ Display uploaded files with information and remove functionality:
   <div class="file-upload-list">
     <!-- File item with thumbnail -->
     <div class="file-upload-item">
-      <img src="preview.jpg" alt="Preview" class="file-upload-item-thumbnail" />
+      <img src="https://picsum.photos/seed/preview/120/120" alt="Preview" class="file-upload-item-thumbnail" />
       <div class="file-upload-item-info">
         <div class="file-upload-item-name">vacation-photo.jpg</div>
         <div class="file-upload-item-size">2.4 MB</div>

--- a/packages/docs/src/content/docs/en/components/list.mdx
+++ b/packages/docs/src/content/docs/en/components/list.mdx
@@ -260,7 +260,7 @@ Use avatars for user-centric lists:
 <ComponentShowcase title="List Items with Avatars" code={`<ul class="list">
   <li class="list-item list-item-interactive list-item-two-line">
     <div class="list-item-leading">
-      <img src="/avatar1.jpg" alt="Ali Connors" class="w-10 h-10 rounded-full">
+      <img src="https://picsum.photos/seed/ali/80/80" alt="Ali Connors" class="w-10 h-10 rounded-full">
     </div>
     <div class="list-item-content">
       <span class="list-item-text">Ali Connors</span>
@@ -269,7 +269,7 @@ Use avatars for user-centric lists:
   </li>
   <li class="list-item list-item-interactive list-item-two-line">
     <div class="list-item-leading">
-      <img src="/avatar2.jpg" alt="Jennifer Smith" class="w-10 h-10 rounded-full">
+      <img src="https://picsum.photos/seed/jennifer/80/80" alt="Jennifer Smith" class="w-10 h-10 rounded-full">
     </div>
     <div class="list-item-content">
       <span class="list-item-text">Jennifer Smith</span>
@@ -593,7 +593,7 @@ Disable interaction with list items:
 <ComponentShowcase title="Accessible List Example" code={`<ul class="list" role="list">
   <li class="list-item list-item-interactive" role="listitem">
     <div class="list-item-leading">
-      <img src="/avatar.jpg" alt="User profile picture" class="w-10 h-10 rounded-full">
+      <img src="https://picsum.photos/seed/profile/80/80" alt="User profile picture" class="w-10 h-10 rounded-full">
     </div>
     <div class="list-item-content">
       <span class="list-item-text">John Doe</span>

--- a/packages/docs/src/content/docs/en/components/modal.mdx
+++ b/packages/docs/src/content/docs/en/components/modal.mdx
@@ -414,7 +414,7 @@ Remove default padding for custom layouts.
     </div>
     <div class="modal-body">
       <!-- Full-width content like images -->
-      <img src="image.jpg" alt="Full width image" />
+      <img src="https://picsum.photos/seed/modal/800/600" alt="Full width image" />
     </div>
   </div>
 </div>`}


### PR DESCRIPTION
## Summary
- Replace local image paths that were returning 404 errors with working picsum.photos placeholder URLs
- Fixed across 5 documentation pages: badge.mdx, chip.mdx, list.mdx, modal.mdx, file-upload.mdx

## Test plan
- [ ] Verify documentation pages load without 404 errors for images
- [ ] Verify placeholder images display correctly in all examples

Closes #11