### PR TITLE
fix: wrap file-upload script blocks in IIFEs to prevent duplicate identifier error

### DIFF
--- a/packages/docs/src/content/docs/en/components/file-upload.mdx
+++ b/packages/docs/src/content/docs/en/components/file-upload.mdx
@@ -38,29 +38,31 @@ The file upload component is designed to work seamlessly with drag-and-drop func
 </div>
 
 <script>
-  const dropzone = document.getElementById('dropzone');
-  const fileInput = document.getElementById('file-drop');
+  (function() {
+    const dropzone = document.getElementById('dropzone');
+    const fileInput = document.getElementById('file-drop');
 
-  dropzone.addEventListener('dragover', (e) => {
-    e.preventDefault();
-    dropzone.classList.add('file-upload-dropzone-dragover');
-  });
+    dropzone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      dropzone.classList.add('file-upload-dropzone-dragover');
+    });
 
-  dropzone.addEventListener('dragleave', () => {
-    dropzone.classList.remove('file-upload-dropzone-dragover');
-  });
+    dropzone.addEventListener('dragleave', () => {
+      dropzone.classList.remove('file-upload-dropzone-dragover');
+    });
 
-  dropzone.addEventListener('drop', (e) => {
-    e.preventDefault();
-    dropzone.classList.remove('file-upload-dropzone-dragover');
-    const files = e.dataTransfer.files;
-    handleFiles(files);
-  });
+    dropzone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      dropzone.classList.remove('file-upload-dropzone-dragover');
+      const files = e.dataTransfer.files;
+      handleFiles(files);
+    });
 
-  function handleFiles(files) {
-    // Handle file upload logic
-    console.log('Files selected:', files);
-  }
+    function handleFiles(files) {
+      // Handle file upload logic
+      console.log('Files selected:', files);
+    }
+  })();
 </script>`} />
 
 ## Multiple Files
@@ -95,7 +97,7 @@ Display uploaded files with information and remove functionality:
   <div class="file-upload-list">
     <!-- File item with thumbnail -->
     <div class="file-upload-item">
-      <img src="preview.jpg" alt="Preview" class="file-upload-item-thumbnail" />
+      <img src="https://picsum.photos/seed/preview/120/120" alt="Preview" class="file-upload-item-thumbnail" />
       <div class="file-upload-item-info">
         <div class="file-upload-item-name">vacation-photo.jpg</div>
         <div class="file-upload-item-size">2.4 MB</div>
@@ -256,108 +258,110 @@ Here's a comprehensive example with all features:
 </div>
 
 <script>
-  const dropzone = document.getElementById('complete-dropzone');
-  const fileInput = document.getElementById('complete-input');
-  const fileList = document.getElementById('complete-list');
-  const maxFiles = 5;
-  const maxSize = 10 * 1024 * 1024; // 10MB
-  let uploadedFiles = [];
+  (function() {
+    const dropzone = document.getElementById('complete-dropzone');
+    const fileInput = document.getElementById('complete-input');
+    const fileList = document.getElementById('complete-list');
+    const maxFiles = 5;
+    const maxSize = 10 * 1024 * 1024; // 10MB
+    let uploadedFiles = [];
 
-  // Drag and drop handlers
-  dropzone.addEventListener('dragover', (e) => {
-    e.preventDefault();
-    dropzone.classList.add('file-upload-dropzone-dragover');
-  });
+    // Drag and drop handlers
+    dropzone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      dropzone.classList.add('file-upload-dropzone-dragover');
+    });
 
-  dropzone.addEventListener('dragleave', () => {
-    dropzone.classList.remove('file-upload-dropzone-dragover');
-  });
+    dropzone.addEventListener('dragleave', () => {
+      dropzone.classList.remove('file-upload-dropzone-dragover');
+    });
 
-  dropzone.addEventListener('drop', (e) => {
-    e.preventDefault();
-    dropzone.classList.remove('file-upload-dropzone-dragover');
-    handleFiles(e.dataTransfer.files);
-  });
+    dropzone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      dropzone.classList.remove('file-upload-dropzone-dragover');
+      handleFiles(e.dataTransfer.files);
+    });
 
-  fileInput.addEventListener('change', (e) => {
-    handleFiles(e.target.files);
-  });
+    fileInput.addEventListener('change', (e) => {
+      handleFiles(e.target.files);
+    });
 
-  function handleFiles(files) {
-    const filesArray = Array.from(files);
+    function handleFiles(files) {
+      const filesArray = Array.from(files);
 
-    if (uploadedFiles.length + filesArray.length > maxFiles) {
-      alert(\`Maximum \${maxFiles} files allowed\`);
-      return;
-    }
-
-    filesArray.forEach(file => {
-      if (file.size > maxSize) {
-        addFileItem(file, true, 'File size exceeds 10MB limit');
-      } else {
-        addFileItem(file, false);
-        uploadedFiles.push(file);
+      if (uploadedFiles.length + filesArray.length > maxFiles) {
+        alert(\`Maximum \${maxFiles} files allowed\`);
+        return;
       }
-    });
 
-    updateMaxFilesState();
-  }
+      filesArray.forEach(file => {
+        if (file.size > maxSize) {
+          addFileItem(file, true, 'File size exceeds 10MB limit');
+        } else {
+          addFileItem(file, false);
+          uploadedFiles.push(file);
+        }
+      });
 
-  function addFileItem(file, hasError = false, errorMessage = '') {
-    const fileItem = document.createElement('div');
-    fileItem.className = \`file-upload-item \${hasError ? 'file-upload-item-error' : ''}\`;
-
-    const isImage = file.type.startsWith('image/');
-    let thumbnail = '';
-
-    if (isImage && !hasError) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const img = fileItem.querySelector('.file-upload-item-thumbnail');
-        if (img) img.src = e.target.result;
-      };
-      reader.readAsDataURL(file);
-      thumbnail = '<img src="" alt="Preview" class="file-upload-item-thumbnail" />';
-    } else {
-      thumbnail = '<div class="file-upload-item-icon">📄</div>';
-    }
-
-    fileItem.innerHTML = \`
-      \${thumbnail}
-      <div class="file-upload-item-info">
-        <div class="file-upload-item-name">\${file.name}</div>
-        <div class="file-upload-item-size">\${formatFileSize(file.size)}</div>
-        \${hasError ? \`<div class="file-upload-item-error-message">\${errorMessage}</div>\` : ''}
-      </div>
-      <button class="file-upload-item-remove" aria-label="Remove file">✕</button>
-    \`;
-
-    const removeBtn = fileItem.querySelector('.file-upload-item-remove');
-    removeBtn.addEventListener('click', () => {
-      fileItem.remove();
-      uploadedFiles = uploadedFiles.filter(f => f !== file);
       updateMaxFilesState();
-    });
-
-    fileList.appendChild(fileItem);
-  }
-
-  function formatFileSize(bytes) {
-    if (bytes === 0) return '0 Bytes';
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i];
-  }
-
-  function updateMaxFilesState() {
-    const container = document.getElementById('complete-upload');
-    if (uploadedFiles.length >= maxFiles) {
-      container.classList.add('file-upload-max-reached');
-    } else {
-      container.classList.remove('file-upload-max-reached');
     }
-  }
+
+    function addFileItem(file, hasError = false, errorMessage = '') {
+      const fileItem = document.createElement('div');
+      fileItem.className = \`file-upload-item \${hasError ? 'file-upload-item-error' : ''}\`;
+
+      const isImage = file.type.startsWith('image/');
+      let thumbnail = '';
+
+      if (isImage && !hasError) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const img = fileItem.querySelector('.file-upload-item-thumbnail');
+          if (img) img.src = e.target.result;
+        };
+        reader.readAsDataURL(file);
+        thumbnail = '<img src="" alt="Preview" class="file-upload-item-thumbnail" />';
+      } else {
+        thumbnail = '<div class="file-upload-item-icon">📄</div>';
+      }
+
+      fileItem.innerHTML = \`
+        \${thumbnail}
+        <div class="file-upload-item-info">
+          <div class="file-upload-item-name">\${file.name}</div>
+          <div class="file-upload-item-size">\${formatFileSize(file.size)}</div>
+          \${hasError ? \`<div class="file-upload-item-error-message">\${errorMessage}</div>\` : ''}
+        </div>
+        <button class="file-upload-item-remove" aria-label="Remove file">✕</button>
+      \`;
+
+      const removeBtn = fileItem.querySelector('.file-upload-item-remove');
+      removeBtn.addEventListener('click', () => {
+        fileItem.remove();
+        uploadedFiles = uploadedFiles.filter(f => f !== file);
+        updateMaxFilesState();
+      });
+
+      fileList.appendChild(fileItem);
+    }
+
+    function formatFileSize(bytes) {
+      if (bytes === 0) return '0 Bytes';
+      const k = 1024;
+      const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+      const i = Math.floor(Math.log(bytes) / Math.log(k));
+      return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i];
+    }
+
+    function updateMaxFilesState() {
+      const container = document.getElementById('complete-upload');
+      if (uploadedFiles.length >= maxFiles) {
+        container.classList.add('file-upload-max-reached');
+      } else {
+        container.classList.remove('file-upload-max-reached');
+      }
+    }
+  })();
 </script>`} />
 
 ## Best Practices


### PR DESCRIPTION
## Summary
- Wrap both script blocks in IIFEs to create separate scopes
- Prevents `SyntaxError: Identifier 'dropzone' has already been declared` when both scripts execute
- Also fixed missing preview.jpg placeholder image

## Test plan
- [ ] Verify file-upload documentation page loads without JS errors
- [ ] Verify drag and drop functionality still works in both examples

Closes #12