### PR TITLE
fix: add wildcard export for individual art CSS files

### DIFF
--- a/packages/css-art/package.json
+++ b/packages/css-art/package.json
@@ -11,7 +11,8 @@
     },
     "./art": {
       "style": "./dist/art/index.css"
-    }
+    },
+    "./dist/art/*.css": "./dist/art/*.css"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- Adds `"./dist/art/*.css": "./dist/art/*.css"` wildcard entry to the `exports` map in `packages/css-art/package.json`
- Allows bundlers (Bun, webpack, etc.) to resolve per-art-piece CSS imports like `@duskmoon-dev/css-art/dist/art/moon.css`

Fixes #23