### PR TITLE
fix(appbar): add flex-grow to appbar-trailing to prevent nav overflow

### DIFF
--- a/packages/core/src/components/appbar.css
+++ b/packages/core/src/components/appbar.css
@@ -244,7 +244,8 @@
     display: flex;
     align-items: center;
     gap: 0.25rem;
-    flex-shrink: 0;
+    flex-grow: 1;
+    justify-content: flex-end;
     margin-left: auto;
   }
 


### PR DESCRIPTION
## Summary
- Changed `.appbar-trailing` from `flex-shrink: 0` to `flex-grow: 1` so it expands to fill available horizontal space
- Added `justify-content: flex-end` to keep trailing items aligned to the right while allowing the container to grow

Fixes #25