### PR TITLE
fix(utilities): include @utility definitions in components CSS export

### DIFF
--- a/packages/core/src/components/index.css
+++ b/packages/core/src/components/index.css
@@ -3,6 +3,9 @@
  * Material Design 3 inspired component library using @layer components
  */
 
+/* Custom utilities (grid-cols-auto-fill-*, grid-cols-auto-fit-*, sr-only) */
+@import "../base/utilities.css";
+
 /* ============================================
  * CORE COMPONENTS (existing)
  * ============================================ */


### PR DESCRIPTION
## Summary
- Added `@import "../base/utilities.css"` to `src/components/index.css` so `grid-cols-auto-fill-*` and `grid-cols-auto-fit-*` utilities are available when using the `@plugin` + `@import "@duskmoon-dev/core/components"` setup
- The build script inlines this import into `dist/components/index.css`, making `@utility` rules available without requiring the root `dist/index.css`

Fixes #26