### PR TITLE
fix(ci): make release workflow idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,13 +76,22 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add packages/core/package.json packages/css-art/package.json
-          git commit -am "chore(release): v${{ inputs.version }}"
-          git push origin HEAD:${{ inputs.git_ref }}
+          if git diff --cached --quiet; then
+            echo "No version changes to commit (already up to date)"
+          else
+            git commit -m "chore(release): v${{ inputs.version }}"
+            git push origin HEAD:${{ inputs.git_ref }}
+          fi
 
       - name: Create git tag
         run: |
-          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
-          git push origin "v${{ inputs.version }}"
+          TAG="v${{ inputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping creation"
+          else
+            git tag -a "$TAG" -m "Release $TAG"
+          fi
+          git push origin "$TAG" --force
 
       - name: Generate release notes
         run: |


### PR DESCRIPTION
## Summary
- Make the "Commit version bump" step skip if versions are already updated (handles re-runs after partial failure)
- Make the "Create git tag" step skip tag creation if the tag already exists, and force-push to handle tag updates
- Add `v*` tag pattern to `github-pages` environment deployment branch policies (the Deploy to GitHub Pages failure was caused by tag refs being rejected by environment protection rules)

## Failures fixed
| Run | Workflow | Root Cause |
|-----|---------|-----------|
| #23423707503 | Release | `fatal: tag 'v1.14.0' already exists` |
| #23170435158 | Publish packages | `fatal: tag 'v1.13.0' already exists` |
| #23452857091 | Deploy to GitHub Pages | Tag not in allowed deployment refs (fixed via API, not code) |

## Not fixed (not actionable)
| Run | Workflow | Reason |
|-----|---------|--------|
| #23157154292, #23153848084 | Claude Code Review | Expected: "workflow file must match default branch" on first PR adding the workflow |

## Test plan
- [x] Verified the `github-pages` environment now accepts `v*` tags
- [ ] Next release dispatch should succeed even if tag already exists