### PR TITLE
fix(chat): separate streaming caret from bubble tail

### DIFF
--- a/packages/core/src/components/chat.css
+++ b/packages/core/src/components/chat.css
@@ -447,28 +447,22 @@
   }
 
   .chat-start .chat-bubble::before,
-  .chat-end .chat-bubble::before,
-  .chat-start .chat-bubble::after,
-  .chat-end .chat-bubble::after {
+  .chat-end .chat-bubble::before {
     content: "";
     position: absolute;
     top: 0;
+    width: calc(1rem - 2px);
+    height: calc(1rem - 2px);
+    background-color: var(--chat-bubble-bg);
     clip-path: polygon(0 0, 100% 0, 100% 100%);
+    filter:
+      drop-shadow(-1px 0 0 var(--color-outline-variant))
+      drop-shadow(0 -1px 0 var(--color-outline-variant));
+    pointer-events: none;
   }
 
   .chat-start .chat-bubble::before {
-    left: -0.625rem;
-    width: 1rem;
-    height: 1rem;
-    background-color: var(--color-outline-variant);
-  }
-
-  .chat-start .chat-bubble::after {
     left: -0.5rem;
-    width: calc(1rem - 2px);
-    height: calc(1rem - 2px);
-    top: 1px;
-    background-color: var(--chat-bubble-bg);
   }
 
   .chat-start .chat-bubble {
@@ -476,19 +470,7 @@
   }
 
   .chat-end .chat-bubble::before {
-    right: -0.625rem;
-    width: 1rem;
-    height: 1rem;
-    background-color: var(--color-outline-variant);
-    transform: scaleX(-1);
-  }
-
-  .chat-end .chat-bubble::after {
     right: -0.5rem;
-    width: calc(1rem - 2px);
-    height: calc(1rem - 2px);
-    top: 1px;
-    background-color: var(--chat-bubble-bg);
     transform: scaleX(-1);
   }
 
@@ -767,13 +749,21 @@
   .chat-bubble-streaming::after,
   .chat-bubble-content.chat-bubble-streaming::after {
     content: "";
+    position: static;
+    inset: auto;
     display: inline-block;
     width: 1px;
     height: 1em;
     margin-left: 0.25rem;
     background-color: currentColor;
+    clip-path: none;
+    transform: none;
     vertical-align: -0.125em;
     animation: chat-stream-caret 1s step-end infinite;
+  }
+
+  .chat-bubble.chat-bubble-streaming:not(:has(.chat-reasoning, .chat-tool, .chat-bubble-content)) {
+    display: block;
   }
 
   .chat-bubble.chat-bubble-streaming:has(.chat-reasoning, .chat-tool, .chat-bubble-content)::after {

--- a/packages/core/tests/unit/chat.test.ts
+++ b/packages/core/tests/unit/chat.test.ts
@@ -160,31 +160,28 @@ describe('Chat Component', () => {
   describe('Bubble tail', () => {
     it('should render start tail with a clipped wedge', () => {
       expect(css).toMatch(
-        /\.chat-start \.chat-bubble::before,\s*\.chat-end \.chat-bubble::before,\s*\.chat-start \.chat-bubble::after,\s*\.chat-end \.chat-bubble::after\s*\{[^}]*clip-path:\s*polygon/s,
+        /\.chat-start \.chat-bubble::before,\s*\.chat-end \.chat-bubble::before\s*\{[^}]*clip-path:\s*polygon/s,
       );
     });
 
     it('should render end tail with mirrored placement', () => {
       expect(css).toMatch(
-        /\.chat-end \.chat-bubble::before\s*\{[^}]*right:\s*-0\.625rem[^}]*transform:\s*scaleX\(-1\)/s,
+        /\.chat-end \.chat-bubble::before\s*\{[^}]*right:\s*-0\.5rem[^}]*transform:\s*scaleX\(-1\)/s,
       );
     });
 
     it('should place bubble tails at the top edge', () => {
       expect(css).toMatch(
-        /\.chat-start \.chat-bubble::before,\s*\.chat-end \.chat-bubble::before,\s*\.chat-start \.chat-bubble::after,\s*\.chat-end \.chat-bubble::after\s*\{[^}]*top:\s*0/s,
+        /\.chat-start \.chat-bubble::before,\s*\.chat-end \.chat-bubble::before\s*\{[^}]*top:\s*0/s,
       );
       expect(css).not.toMatch(
-        /\.chat-start \.chat-bubble::before,\s*\.chat-end \.chat-bubble::before,\s*\.chat-start \.chat-bubble::after,\s*\.chat-end \.chat-bubble::after\s*\{[^}]*bottom:\s*0/s,
+        /\.chat-start \.chat-bubble::before,\s*\.chat-end \.chat-bubble::before\s*\{[^}]*bottom:\s*0/s,
       );
     });
 
-    it('should render larger tails with explicit border strokes and matching fill', () => {
+    it('should render outlined tails with matching bubble fill', () => {
       expect(css).toMatch(
-        /\.chat-start \.chat-bubble::before\s*\{[^}]*width:\s*1rem[^}]*height:\s*1rem[^}]*background-color:\s*var\(--color-outline-variant\)/s,
-      );
-      expect(css).toMatch(
-        /\.chat-start \.chat-bubble::after\s*\{[^}]*width:\s*calc\(1rem - 2px\)[^}]*height:\s*calc\(1rem - 2px\)[^}]*background-color:\s*var\(--chat-bubble-bg\)/s,
+        /\.chat-start \.chat-bubble::before,\s*\.chat-end \.chat-bubble::before\s*\{[^}]*width:\s*calc\(1rem - 2px\)[^}]*height:\s*calc\(1rem - 2px\)[^}]*background-color:\s*var\(--chat-bubble-bg\)[^}]*filter:\s*drop-shadow/s,
       );
     });
 
@@ -303,6 +300,18 @@ describe('Chat Component', () => {
       expect(css).toContain('@keyframes chat-typing-dot');
       expect(css).toContain('@keyframes chat-stream-caret');
       expect(css).toContain('@keyframes chat-tool-spin');
+    });
+
+    it('should keep the streaming caret separate from the bubble tail', () => {
+      expect(css).toMatch(
+        /\.chat-start \.chat-bubble::before,\s*\.chat-end \.chat-bubble::before\s*\{[^}]*filter:\s*drop-shadow/s,
+      );
+      expect(css).toMatch(
+        /\.chat-bubble\.chat-bubble-streaming:not\(:has\([^)]+\)\)\s*\{[^}]*display:\s*block/s,
+      );
+      expect(css).toMatch(
+        /\.chat-bubble-streaming::after,\s*\.chat-bubble-content\.chat-bubble-streaming::after\s*\{[^}]*position:\s*static[^}]*clip-path:\s*none/s,
+      );
     });
 
     it('should include reduced motion fallbacks', () => {


### PR DESCRIPTION
## Summary
- preserve outlined directional bubble tails with a dedicated pseudo-element
- render ordinary streaming carets inline without overriding tail geometry
- add regression coverage for start/end streaming bubbles

Fixes #50