### PR TITLE
fix(switch): emit valid transition declarations

### DIFF
--- a/packages/core/src/components/switch.css
+++ b/packages/core/src/components/switch.css
@@ -34,8 +34,8 @@
     border: 2px solid var(--switch-border-color);
     border-radius: var(--switch-height);
     /* Use !important to override global * { transition } rules from layers */
-    transition: background-color 200ms ease-in-out !important,
-      border-color 200ms ease-in-out !important,
+    transition: background-color 200ms ease-in-out,
+      border-color 200ms ease-in-out,
       grid-template-columns 200ms ease-in-out !important;
   }
 
@@ -48,8 +48,8 @@
     background-color: var(--switch-thumb-color);
     border-radius: var(--radius-full);
     /* Use !important to override global * { transition } rules */
-    transition: background-color 200ms ease-in-out !important,
-      width 200ms ease-in-out !important,
+    transition: background-color 200ms ease-in-out,
+      width 200ms ease-in-out,
       margin 200ms ease-in-out !important;
   }
 

--- a/packages/core/tests/unit/switch.test.ts
+++ b/packages/core/tests/unit/switch.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, beforeAll } from 'bun:test';
 import { readFile } from 'fs/promises';
 import { resolve } from 'path';
+import { transform } from 'lightningcss';
 
 describe('Switch Component', () => {
   let css: string;
@@ -32,6 +33,25 @@ describe('Switch Component', () => {
       expect(css).toContain('--switch-height');
       expect(css).toContain('--switch-thumb-size');
       expect(css).toContain('--switch-color');
+    });
+
+    it('should keep important after each complete transition list', () => {
+      expect(css).toMatch(
+        /transition:\s*background-color 200ms ease-in-out,\s*border-color 200ms ease-in-out,\s*grid-template-columns 200ms ease-in-out !important;/s,
+      );
+      expect(css).toMatch(
+        /transition:\s*background-color 200ms ease-in-out,\s*width 200ms ease-in-out,\s*margin 200ms ease-in-out !important;/s,
+      );
+    });
+
+    it('should compile with Lightning CSS', () => {
+      expect(() =>
+        transform({
+          filename: 'switch.css',
+          code: Buffer.from(css),
+          minify: true,
+        }),
+      ).not.toThrow();
     });
   });
 


### PR DESCRIPTION
## Summary
- apply !important once at the end of each switch transition list
- add Lightning CSS regression coverage for source declarations
- verify the built component CSS minifies successfully

Fixes #49