### PR TITLE
fix: ship documented data modifier classes

### DIFF
--- a/packages/core/src/components/badge.css
+++ b/packages/core/src/components/badge.css
@@ -71,112 +71,141 @@
   }
 
   /* Outlined Variants */
+  .badge-outlined,
+  .badge-outlined-secondary,
+  .badge-outlined-tertiary,
   .badge-outline {
     background-color: transparent;
     border: 1px solid currentColor;
   }
 
+  .badge-outlined,
+  .badge-outlined.badge-primary,
   .badge-outline.badge-primary {
     color: var(--color-primary);
     border-color: var(--color-primary);
   }
 
+  .badge-outlined.badge-secondary,
+  .badge-outlined-secondary,
   .badge-outline.badge-secondary {
     color: var(--color-secondary);
     border-color: var(--color-secondary);
   }
 
+  .badge-outlined.badge-tertiary,
+  .badge-outlined-tertiary,
   .badge-outline.badge-tertiary {
     color: var(--color-tertiary);
     border-color: var(--color-tertiary);
   }
 
+  .badge-outlined.badge-accent,
   .badge-outline.badge-accent {
     color: var(--color-accent);
     border-color: var(--color-accent);
   }
 
+  .badge-outlined.badge-neutral,
   .badge-outline.badge-neutral {
     color: var(--color-neutral);
     border-color: var(--color-neutral);
   }
 
+  .badge-outlined.badge-base,
   .badge-outline.badge-base {
     color: var(--color-base-content);
     border-color: var(--color-base-content);
   }
 
+  .badge-outlined.badge-info,
   .badge-outline.badge-info {
     color: var(--color-info);
     border-color: var(--color-info);
   }
 
+  .badge-outlined.badge-success,
   .badge-outline.badge-success {
     color: var(--color-success);
     border-color: var(--color-success);
   }
 
+  .badge-outlined.badge-warning,
   .badge-outline.badge-warning {
     color: var(--color-warning);
     border-color: var(--color-warning);
   }
 
+  .badge-outlined.badge-error,
   .badge-outline.badge-error {
     color: var(--color-error);
     border-color: var(--color-error);
   }
 
   /* Soft/Tonal Variants */
+  .badge-tonal,
   .badge-soft {
     background-color: var(--color-primary-container);
     color: var(--color-on-primary-container);
   }
 
+  .badge-tonal.badge-primary,
   .badge-soft.badge-primary {
     background-color: var(--color-primary-container);
     color: var(--color-on-primary-container);
   }
 
+  .badge-tonal.badge-secondary,
+  .badge-tonal-secondary,
   .badge-soft.badge-secondary {
     background-color: var(--color-secondary-container);
     color: var(--color-on-secondary-container);
   }
 
+  .badge-tonal.badge-tertiary,
+  .badge-tonal-tertiary,
   .badge-soft.badge-tertiary {
     background-color: var(--color-tertiary-container);
     color: var(--color-on-tertiary-container);
   }
 
+  .badge-tonal.badge-accent,
   .badge-soft.badge-accent {
     background-color: color-mix(in oklch, var(--color-accent) 15%, var(--color-surface));
     color: var(--color-on-surface);
   }
 
+  .badge-tonal.badge-neutral,
   .badge-soft.badge-neutral {
     background-color: color-mix(in oklch, var(--color-neutral) 15%, var(--color-surface));
     color: var(--color-on-surface);
   }
 
+  .badge-tonal.badge-base,
   .badge-soft.badge-base {
     background-color: var(--color-base-200);
     color: var(--color-base-content);
   }
 
+  .badge-tonal.badge-info,
   .badge-soft.badge-info {
     background-color: var(--color-info-container);
     color: var(--color-on-info-container);
   }
 
+  .badge-tonal.badge-success,
   .badge-soft.badge-success {
     background-color: var(--color-success-container);
     color: var(--color-on-success-container);
   }
 
+  .badge-tonal.badge-warning,
   .badge-soft.badge-warning {
     background-color: var(--color-warning-container);
     color: var(--color-on-warning-container);
   }
 
+  .badge-tonal.badge-error,
   .badge-soft.badge-error {
     background-color: var(--color-error-container);
     color: var(--color-on-error-container);

--- a/packages/core/src/components/button.css
+++ b/packages/core/src/components/button.css
@@ -625,6 +625,25 @@
   }
 
   /* Icon Button */
+  .btn-icon {
+    padding: 0.75rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: var(--radius-full);
+  }
+
+  .btn-icon-sm {
+    padding: 0.5rem;
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .btn-icon-lg {
+    padding: 1rem;
+    width: 3rem;
+    height: 3rem;
+  }
+
   .btn-circle {
     --btn-p: 0.625rem;
     --btn-py: 0.625rem;

--- a/packages/core/src/components/table.css
+++ b/packages/core/src/components/table.css
@@ -13,6 +13,11 @@
     color: var(--color-on-surface);
   }
 
+  /* Surface Variant */
+  .table-surface {
+    background-color: var(--color-surface);
+  }
+
   /* Table Head */
   .table thead,
   .table-header {
@@ -60,7 +65,9 @@
 
   /* Zebra Striping */
   .table-zebra tbody tr:nth-child(even),
-  .table-zebra .table-row:nth-child(even) {
+  .table-zebra .table-row:nth-child(even),
+  .table-striped tbody tr:nth-child(even),
+  .table-striped .table-row:nth-child(even) {
     background-color: var(--color-surface-container-low);
   }
 
@@ -82,6 +89,16 @@
     border: 1px solid var(--color-outline-variant);
   }
 
+  /* Borderless Table */
+  .table-borderless,
+  .table-borderless th,
+  .table-borderless td,
+  .table-borderless tfoot td,
+  .table-borderless .table-header-cell,
+  .table-borderless .table-cell {
+    border: none;
+  }
+
   /* Compact Table */
   .table-compact th,
   .table-compact td {
@@ -98,6 +115,16 @@
   /* Fixed Layout */
   .table-fixed {
     table-layout: fixed;
+  }
+
+  /* Sticky Header */
+  .table-sticky thead,
+  .table-sticky .table-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background-color: var(--color-surface-container);
+    box-shadow: var(--shadow-xs);
   }
 
   /* Sortable Header */
@@ -120,9 +147,24 @@
     opacity: 0.7;
   }
 
+  /* Selectable Rows */
+  .table-selectable tbody tr,
+  .table-selectable .table-row {
+    cursor: pointer;
+  }
+
+  .table-selectable tbody tr:hover,
+  .table-selectable .table-row:hover {
+    background-color: color-mix(in oklch, var(--color-on-surface) 8%, transparent);
+  }
+
   /* Selected Row */
   .table-row-selected,
-  .table tr.selected {
+  .table tr.selected,
+  .table-selectable tbody tr.table-row-selected,
+  .table-selectable .table-row.table-row-selected,
+  .table-selectable tbody tr.selected,
+  .table-selectable .table-row.selected {
     background-color: var(--color-primary-container);
     color: var(--color-on-primary-container);
   }

--- a/packages/core/tests/unit/badge.test.ts
+++ b/packages/core/tests/unit/badge.test.ts
@@ -226,6 +226,60 @@ describe('Badge Component', () => {
     });
   });
 
+  describe('Legacy Tonal and Outlined Aliases', () => {
+    it('should expose the documented tonal and outlined aliases', () => {
+      expect(css).toContain('.badge-tonal');
+      expect(css).toContain('.badge-outlined');
+    });
+
+    for (const color of ['secondary', 'tertiary']) {
+      it(`should expose single-class tonal and outlined ${color} aliases`, () => {
+        expect(css).toMatch(
+          new RegExp(
+            `\\.badge-tonal-${color},\\s*\\.badge-soft\\.badge-${color}\\s*\\{[^}]*background-color:\\s*var\\(--color-${color}-container\\)[^}]*color:\\s*var\\(--color-on-${color}-container\\)`,
+            's',
+          ),
+        );
+        expect(css).toMatch(
+          new RegExp(
+            `\\.badge-outlined\\.badge-${color},\\s*\\.badge-outlined-${color},\\s*\\.badge-outline\\.badge-${color}\\s*\\{[^}]*color:\\s*var\\(--color-${color}\\)[^}]*border-color:\\s*var\\(--color-${color}\\)`,
+            's',
+          ),
+        );
+        expect(css).toMatch(
+          new RegExp(
+            `\\.badge-outlined-${color},[\\s\\S]*?\\.badge-outline\\s*\\{[^}]*background-color:\\s*transparent[^}]*border:\\s*1px solid currentColor`,
+            's',
+          ),
+        );
+      });
+    }
+
+    for (const color of [
+      'primary',
+      'secondary',
+      'tertiary',
+      'info',
+      'success',
+      'warning',
+      'error',
+    ]) {
+      it(`should compose tonal and outlined aliases with badge-${color}`, () => {
+        expect(css).toContain(`.badge-tonal.badge-${color}`);
+        expect(css).toContain(`.badge-outlined.badge-${color}`);
+      });
+    }
+
+    it('should share canonical declarations for composed semantic aliases', () => {
+      expect(css).toMatch(
+        /\.badge-tonal\.badge-success,\s*\.badge-soft\.badge-success\s*\{[^}]*background-color:\s*var\(--color-success-container\)[^}]*color:\s*var\(--color-on-success-container\)/s,
+      );
+      expect(css).toMatch(
+        /\.badge-outlined\.badge-warning,\s*\.badge-outline\.badge-warning\s*\{[^}]*color:\s*var\(--color-warning\)[^}]*border-color:\s*var\(--color-warning\)/s,
+      );
+    });
+  });
+
   describe('Size Variants', () => {
     it('should define .badge-sm class', () => {
       expect(css).toContain('.badge-sm');

--- a/packages/core/tests/unit/button.test.ts
+++ b/packages/core/tests/unit/button.test.ts
@@ -148,6 +148,31 @@ describe('Button Component', () => {
     });
   });
 
+  describe('Icon Button Variants', () => {
+    const iconSizes = [
+      { className: 'btn-icon', padding: '0.75rem', size: '2.5rem' },
+      { className: 'btn-icon-sm', padding: '0.5rem', size: '2rem' },
+      { className: 'btn-icon-lg', padding: '1rem', size: '3rem' },
+    ];
+
+    for (const { className, padding, size } of iconSizes) {
+      it(`should define .${className} with the documented dimensions`, () => {
+        expect(buttonCSS).toMatch(
+          new RegExp(
+            `\\.${className}\\s*\\{[^}]*padding:\\s*${padding}[^}]*width:\\s*${size}[^}]*height:\\s*${size}`,
+            's',
+          ),
+        );
+      });
+    }
+
+    it('should keep icon buttons circular', () => {
+      expect(buttonCSS).toMatch(
+        /\.btn-icon\s*\{[^}]*border-radius:\s*var\(--radius-full\)/s,
+      );
+    });
+  });
+
   describe('Interactive States', () => {
     it('should define hover state styles', () => {
       expect(buttonCSS).toMatch(/\.btn[^{]*:hover/);

--- a/packages/core/tests/unit/table.test.ts
+++ b/packages/core/tests/unit/table.test.ts
@@ -143,6 +143,55 @@ describe('Table Component', () => {
     });
   });
 
+  describe('Documented Compatibility Modifiers', () => {
+    it('should support .table-striped as a zebra-striping alias', () => {
+      expect(css).toMatch(
+        /\.table-striped tbody tr:nth-child\(even\)[\s\S]*?background-color:\s*var\(--color-surface-container-low\)/,
+      );
+    });
+
+    it('should remove cell borders for .table-borderless', () => {
+      expect(css).toMatch(
+        /\.table-borderless th,[\s\S]*?\.table-borderless td[\s\S]*?border:\s*none/,
+      );
+      expect(css).toContain('.table-borderless tfoot td');
+      expect(css).toContain('.table-borderless .table-cell');
+    });
+
+    it('should make .table-sticky headers sticky', () => {
+      expect(css).toMatch(
+        /\.table-sticky thead[\s\S]*?position:\s*sticky[\s\S]*?top:\s*0/,
+      );
+    });
+
+    it('should expose selectable row states', () => {
+      expect(css).toMatch(
+        /\.table-selectable tbody tr[\s\S]*?cursor:\s*pointer/,
+      );
+      expect(css).toContain('.table-selectable tbody tr:hover');
+      expect(css).toContain('.table-selectable tbody tr.selected');
+    });
+
+    it('should keep both selected-row forms above selectable hover styles', () => {
+      const hoverRule = css.indexOf('.table-selectable tbody tr:hover');
+      const nativeSelectedRule = css.indexOf(
+        '.table-selectable tbody tr.table-row-selected',
+      );
+      const classSelectedRule = css.indexOf(
+        '.table-selectable .table-row.table-row-selected',
+      );
+
+      expect(nativeSelectedRule).toBeGreaterThan(hoverRule);
+      expect(classSelectedRule).toBeGreaterThan(hoverRule);
+    });
+
+    it('should expose the surface background modifier', () => {
+      expect(css).toMatch(
+        /\.table-surface\s*\{[^}]*background-color:\s*var\(--color-surface\)/s,
+      );
+    });
+  });
+
   describe('Hover Effect', () => {
     it('should define .table-hover class', () => {
       expect(css).toContain('.table-hover');


### PR DESCRIPTION
## Summary
- add published Core CSS for the documented icon-button and table modifiers
- restore tonal and outlined badge aliases with composable color parity
- add regression coverage for dimensions, alias declarations, and selected-row cascade behavior

## Tests
- cd packages/core && bun test tests/unit (1994 pass)
- bun run build:core
- bun run typecheck

Fixes #53