### PR TITLE
fix: suppress tooltip popover overflow scrollbars

### DIFF
--- a/packages/core/src/components/tooltip.css
+++ b/packages/core/src/components/tooltip.css
@@ -34,6 +34,7 @@
     pointer-events: none;
     opacity: 0;
     transform: scale(0.95);
+    overflow: visible;
     position-area: top;
     position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
     transition:

--- a/packages/core/src/components/tooltip.ts
+++ b/packages/core/src/components/tooltip.ts
@@ -23,6 +23,7 @@ export const tooltipStyles: Record<string, any> = {
     pointerEvents: 'none',
     opacity: '0',
     transform: 'scale(0.95)',
+    overflow: 'visible',
     positionArea: 'top',
     positionTryFallbacks: 'flip-block, flip-inline, flip-block flip-inline',
   },

--- a/packages/core/tests/unit/tooltip.test.ts
+++ b/packages/core/tests/unit/tooltip.test.ts
@@ -97,6 +97,12 @@ describe('Tooltip Component', () => {
         /\.tooltip\[popover\]\s*\{[^}]*pointer-events:\s*none/s
       );
     });
+
+    it('should set overflow visible to suppress UA popover scrollbar', () => {
+      expect(css).toMatch(
+        /\.tooltip\[popover\]\s*\{[^}]*overflow:\s*visible/s
+      );
+    });
   });
 
   describe('Arrow', () => {


### PR DESCRIPTION
## Summary
- Suppress horizontal overflow scrollbar on `.tooltip[popover]` by setting `overflow: visible`
- Update tooltip styles and add unit tests

Fixes #55