### PR TITLE
fix: target sticky header styling on table header cells

### DIFF
--- a/packages/core/src/components/table.css
+++ b/packages/core/src/components/table.css
@@ -127,6 +127,16 @@
     box-shadow: var(--shadow-xs);
   }
 
+  .table-sticky th,
+  .table-sticky thead th,
+  .table-sticky .table-header-cell {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background-color: var(--color-surface-container);
+    box-shadow: var(--shadow-xs);
+  }
+
   /* Sortable Header */
   .table-sortable th {
     cursor: pointer;

--- a/packages/core/src/components/table.ts
+++ b/packages/core/src/components/table.ts
@@ -87,6 +87,13 @@ export const tableStyles: Record<string, any> = {
     backgroundColor: 'var(--color-surface-container)',
     boxShadow: 'var(--shadow-xs)',
   },
+  '.table-sticky th, .table-sticky thead th, .table-sticky .table-header-cell': {
+    position: 'sticky',
+    top: '0',
+    zIndex: '10',
+    backgroundColor: 'var(--color-surface-container)',
+    boxShadow: 'var(--shadow-xs)',
+  },
 
   // Sortable column
   '.table-sort': {

--- a/packages/core/tests/unit/table.test.ts
+++ b/packages/core/tests/unit/table.test.ts
@@ -162,6 +162,12 @@ describe('Table Component', () => {
       expect(css).toMatch(
         /\.table-sticky thead[\s\S]*?position:\s*sticky[\s\S]*?top:\s*0/,
       );
+      expect(css).toMatch(
+        /\.table-sticky th[\s\S]*?position:\s*sticky[\s\S]*?top:\s*0/,
+      );
+      expect(css).toMatch(
+        /\.table-sticky th[\s\S]*?background-color:\s*var\(--color-surface-container\)/,
+      );
     });
 
     it('should expose selectable row states', () => {


### PR DESCRIPTION
## Summary
- Apply `position: sticky`, `top: 0`, and background color directly to `.table-sticky th` and `.table-sticky .table-header-cell` to ensure sticky table headers work inside scroll containers with collapsed borders in Chromium
- Add unit tests

Fixes #56